### PR TITLE
Refactor/rename userid to author in post

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -40,10 +40,22 @@ const tokenChecker = (req, res, next) => {
   });
 };
 
+// middleware function specifically for /users
+// which allows creating a new user without a valid token
+// but disallows other actions without a valid token
+
+const usersTokenChecker = (req, res, next) => {
+  if (req.method == "POST") {
+    next();
+  } else {
+    tokenChecker(req, res, next);
+  }
+}
+
 // route setup
 app.use("/posts", tokenChecker, postsRouter);
 app.use("/tokens", authenticationRouter);
-app.use("/users", tokenChecker, usersRouter);
+app.use("/users", usersTokenChecker, usersRouter);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/api/app.js
+++ b/api/app.js
@@ -26,12 +26,12 @@ const tokenChecker = (req, res, next) => {
   if(authHeader) {
     token = authHeader.slice(7)
   }
-  console.log("!!!!!!!!!authHeader");
-  console.log(authHeader);
+  // console.log("!!!!!!!!!authHeader");
+  // console.log(authHeader);
 
   JWT.verify(token, process.env.JWT_SECRET, (err, payload) => {
     if(err) {
-      console.log(err)
+      //console.log(err)
       res.status(401).json({message: "auth error"});
     } else {
       req.user_id = payload.user_id;

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -31,7 +31,12 @@ const PostsController = {
     });
   },
 
-  IndexByUserId: (req, res) => {
+  IndexLoggedInUser: (req, res) => {
+    // req.user_id is ALWAYS the id of the *logged in user*.
+    // Therefore this function ALWAYS finds the posts
+    // of the *logged in user*.
+    // Therefore I have renamed this function
+    // from `IndexByUserId` to `IndexLoggedInUser`.
     const userId = req.user_id;
     Post.find({ userId: userId }, (err, posts) => {
       if (err) {

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -26,7 +26,7 @@ const PostsController = {
         throw err;
       }
       const token = TokenGenerator.jsonwebtoken(req.user_id);
-      console.log(posts);
+      //console.log(posts);
       res.status(200).json({ posts: posts, token: token });
     });
   },

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -37,8 +37,8 @@ const PostsController = {
     // of the *logged in user*.
     // Therefore I have renamed this function
     // from `IndexByUserId` to `IndexLoggedInUser`.
-    const userId = req.user_id;
-    Post.find({ userId: userId }, (err, posts) => {
+    const author = req.user_id;
+    Post.find({ author: author }, (err, posts) => {
       if (err) {
         return res.status(500).json({ error: err.message });
       }
@@ -49,7 +49,9 @@ const PostsController = {
 
   Create: (req, res) => {
     try {
-      const userId = req.user_id; //takes user_id from Schema
+      // req.user_id is the id of the currently logged in user.
+      // the middleware function tokenChecker sets this on the request.
+      const author = req.user_id; //takes user_id from Schema
       const { message } = req.body;
       const imageBuffer = req.file ? req.file.buffer : null //check image added
 
@@ -63,7 +65,7 @@ const PostsController = {
         ...req.body,
         message,
         image: imageUrl,
-        userId: userId
+        author: author
       });
 
       post.save((err) => {
@@ -86,9 +88,9 @@ const PostsController = {
     const newComment = req.body.comment;
 
     try {
-      // Fetch user information based on userId
-      const user = await User.findById(req.user_id);
-      if (!user) {
+      // Fetch user information based on user_id
+      const activeUser = await User.findById(req.user_id);
+      if (!activeUser) {
         throw new Error("User not found");
       }
 
@@ -99,8 +101,12 @@ const PostsController = {
           $push: {
             comments: {
               comment_message: newComment,
+              // TODO: Change this as this is incorrect logic if the user is able
+              // to change their displayName
+              // (The user could change their displayName but the comment would
+              // retain the previous displayName)
               username: user.displayName, // Assuming displayName is the user's username
-              userId: req.user_id
+              commenter: req.user_id
             },
           },
         },
@@ -112,9 +118,18 @@ const PostsController = {
           } else {
             console.log('Comment added successfully');
             const token = TokenGenerator.jsonwebtoken(req.user_id);
+            // What is this code intented to do?
+            //   Currently it is setting a field which is meant to contain a user's id
+            //   to a username, which is a string. The types don't match so this can't
+            //   be correctly implemented in the current form.
+            //   If it's meant to solve the above issue with username.displayName,
+            //   then it should be setting comment.username instead.
+            // - Perran
+            /*
             updatedPost.comments.forEach(comment => {
-              comment.userId = comment.username;
+              comment.commenter = comment.username;
             });
+            */
             console.log(updatedPost);
             res.status(201).json({ message: 'Comment added successfully', token: token, updatedPost });
           }

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -65,7 +65,7 @@ const PostsController = {
         if (err) {
           throw err;
         }
-      );
+      });
 
       const token = TokenGenerator.jsonwebtoken(req.user_id);
       res.status(201).json({ message: 'OK', token });

--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -13,21 +13,24 @@ const UsersController = {
     });
   },
 
-FindSingleUserById: (req, res) => {
-  const userId = req.user_id; 
-  User.findById(userId).select('displayName').exec((err, user) => {
-    if (err) {
-      // Handle error
-      res.status(500).json({ error: 'Internal Server Error' });
-    } else if (!user) {
-      // Handle case where user is not found
-      res.status(404).json({ error: 'User not found' });
-    } else {
-      // User found, send back the displayName
-      const token = TokenGenerator.jsonwebtoken(req.user_id)
-      res.status(200).json({ displayName: user.displayName });
-    }
-  });
-},
+  // This function returns a *displayName*, not a user object,
+  // so I've renamed it
+  // - Perran
+  FindSingleDisplayNameById: (req, res) => {
+    const userId = req.user_id; 
+    User.findById(userId).select('displayName').exec((err, user) => {
+      if (err) {
+        // Handle error
+        res.status(500).json({ error: 'Internal Server Error' });
+      } else if (!user) {
+        // Handle case where user is not found
+        res.status(404).json({ error: 'User not found' });
+      } else {
+        // User found, send back the displayName
+        const token = TokenGenerator.jsonwebtoken(req.user_id)
+        res.status(200).json({ displayName: user.displayName });
+      }
+    });
+  },
 };
 module.exports = UsersController;

--- a/api/models/post.js
+++ b/api/models/post.js
@@ -6,13 +6,13 @@ const PostSchema = new mongoose.Schema({
   date: { type: Date, default: Date.now },
   comments: [{ comment_message: String, date: { type: Date, default: Date.now }}],
   likes: { type: Number, default: 0 },
-  userId: {
+  author: {
     type: mongoose.Schema.Types.ObjectId,
     ref:'User',
     required: true
   },
   comments: [{ comment_message: String, date: { type: Date, default: Date.now }, 
-    userId: {
+    commenter: {
     type: mongoose.Schema.Types.ObjectId,
     ref:'User',
     required: true

--- a/api/routes/posts.js
+++ b/api/routes/posts.js
@@ -10,7 +10,9 @@ const upload = multer({ storage: storage });
 router.post("/", upload.single('image'), PostsController.Create);
 router.get("/", PostsController.Index);
 router.post("/", PostsController.Create);
-router.get("/user", PostsController.IndexByUserId);
+// PostsController.IndexLoggedInUser gets the posts
+// of the *currently logged in* user.
+router.get("/user", PostsController.IndexLoggedInUser);
 router.put("/:id", PostsController.Comment);
 router.put("/:id/likes", PostsController.Likes);
 router.get("/:id/likes", PostsController.GetLikes);

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const UsersController = require("../controllers/users");
 
 router.post("/", UsersController.Create);
-router.get("/user", UsersController.FindSingleUserById);
+router.get("/display-name", UsersController.FindSingleDisplayNameById);
 
   // NEED TO RETURN TO THIS (TODO)
   // router.get("/users", UsersController.FindAll);

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -87,8 +87,8 @@ describe("/posts", () => {
 
 describe("GET, when token is present", () => {
     test("returns every post in the collection", async () => {
-        let post1 = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
-        let post2 = new Post({message: "hola!", userId: '6555fb6dc0a21062095c4a2c'});
+        let post1 = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
+        let post2 = new Post({message: "hola!", author: '6555fb6dc0a21062095c4a2c'});
         await post1.save();
         await post2.save();
         let response = await request(app)
@@ -100,8 +100,8 @@ describe("GET, when token is present", () => {
     })
 
     test("the response code is 200", async () => {
-        let post1 = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
-        let post2 = new Post({message: "hola!", userId: '6555fb6dc0a21062095c4a2c'});
+        let post1 = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
+        let post2 = new Post({message: "hola!", author: '6555fb6dc0a21062095c4a2c'});
         await post1.save();
         await post2.save();
         let response = await request(app)
@@ -112,8 +112,8 @@ describe("GET, when token is present", () => {
     })
 
     test("returns a new token", async () => {
-        let post1 = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
-        let post2 = new Post({message: "hola!", userId: '6555fb6dc0a21062095c4a2c'});
+        let post1 = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
+        let post2 = new Post({message: "hola!", author: '6555fb6dc0a21062095c4a2c'});
         await post1.save();
         await post2.save();
         let response = await request(app)
@@ -128,8 +128,8 @@ describe("GET, when token is present", () => {
 
     describe("GET, when token is missing", () => {
     test("returns no posts", async () => {
-        let post1 = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
-        let post2 = new Post({message: "hola!", userId: '6555fb6dc0a21062095c4a2c'});
+        let post1 = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
+        let post2 = new Post({message: "hola!", author: '6555fb6dc0a21062095c4a2c'});
         await post1.save();
         await post2.save();
         let response = await request(app)
@@ -138,8 +138,8 @@ describe("GET, when token is present", () => {
     })
 
     test("the response code is 401", async () => {
-        let post1 = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
-        let post2 = new Post({message: "hola!", userId: '6555fb6dc0a21062095c4a2c'});
+        let post1 = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
+        let post2 = new Post({message: "hola!", author: '6555fb6dc0a21062095c4a2c'});
         await post1.save();
         await post2.save();
         let response = await request(app)
@@ -148,8 +148,8 @@ describe("GET, when token is present", () => {
     })
 
     test("does not return a new token", async () => {
-        let post1 = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
-        let post2 = new Post({message: "hola!", userId: '6555fb6dc0a21062095c4a2c'});
+        let post1 = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
+        let post2 = new Post({message: "hola!", author: '6555fb6dc0a21062095c4a2c'});
         await post1.save();
         await post2.save();
         let response = await request(app)
@@ -177,7 +177,7 @@ describe('Put Comment Route', () => {
 describe('PUT /posts/:id', () => {
     it('should add a comment to a post', async () => {
       // Create a mock post in the database
-        const mockPost = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
+        const mockPost = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
         await mockPost.save();
 
         const commentData = {
@@ -214,7 +214,7 @@ describe('Put Likes Route', () => {
 describe('PUT /posts/:id/likes', () => {
     it('should initiate at 0', async () => {
       // Create a mock post in the database
-        const mockPost = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
+        const mockPost = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
         await mockPost.save();
 
         const likesData = {
@@ -248,7 +248,7 @@ describe('Put Likes Route', () => {
     describe('PUT /posts/:id/likes', () => {
     it('should add a like to a post', async () => {
       // Create a mock post in the database
-        const mockPost = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
+        const mockPost = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
         await mockPost.save();
 
         const likesData = {
@@ -283,7 +283,7 @@ describe('Put Likes Route', () => {
     describe('PUT /posts/:id/likes', () => {
     it('should add a like to a post then remove it', async () => {
       // Create a mock post in the database
-        const mockPost = new Post({message: "howdy!", userId: '6555fb6dc0a21062095c4a2b'});
+        const mockPost = new Post({message: "howdy!", author: '6555fb6dc0a21062095c4a2b'});
         await mockPost.save();
 
         const likesData = {
@@ -327,7 +327,7 @@ describe('GET /posts/:id/likes', () => {
 
     it('should return post likes and token for a valid post ID', async () => {
         // Create a mock post in the database
-        const mockPost = new Post({ message: "howdy!", userId: '6555fb6dc0a21062095c4a2b', likes: 341 });
+        const mockPost = new Post({ message: "howdy!", author: '6555fb6dc0a21062095c4a2b', likes: 341 });
         await mockPost.save();
 
         // Mock user data for JWT token creation

--- a/api/spec/controllers/users.spec.js
+++ b/api/spec/controllers/users.spec.js
@@ -165,8 +165,10 @@ describe("/users", () => {
       // Create the two users.
       await createTestUser(userInfo1);
       const user1 = await getMostRecentlyCreatedUser();
+      //console.log(`USER 1: ${user1}`);
       await createTestUser(userInfo2);
       const user2 = await getMostRecentlyCreatedUser();
+      //console.log(`USER 2: ${user2}`);
       // Log in as User One.
       let token1 = logInAndGetTokenAs(user1);
       // As User One, search for User Two.

--- a/api/spec/models/post.spec.js
+++ b/api/spec/models/post.spec.js
@@ -43,7 +43,7 @@ describe("Post model", () => {
   });
 
   it("can save a post", (done) => {
-    var post = new Post({ message: "some message", userId: '6555fb6dc0a21062095c4a2b' });
+    var post = new Post({ message: "some message", author: '6555fb6dc0a21062095c4a2b' });
 
     post.save((err) => {
       expect(err).toBeNull();

--- a/frontend/src/components/auth/LoginForm.js
+++ b/frontend/src/components/auth/LoginForm.js
@@ -12,12 +12,11 @@ const LogInForm = ({ navigate }) => {
       headers: {
         'Content-Type': 'application/json',
       },
-// <<<<<<< HEAD
       body: JSON.stringify({ email: email, password: password })
     });
     if (response.status === 201) {
       // GOOD NEWS.
-      console.log("token");
+      // console.log("token");
       let data = await response.json();
       window.localStorage.setItem("token", data.token);
       navigate('/posts');
@@ -45,7 +44,7 @@ const LogInForm = ({ navigate }) => {
 
 //   const handleDisplayNameChange = (event) => {
 //     setDisplayName(event.target.value)
-// >>>>>>> 1532bdb (I added comments)
+
   }
 
   const handleEmailChange = (event) => {

--- a/frontend/src/components/profile/Profile.js
+++ b/frontend/src/components/profile/Profile.js
@@ -16,7 +16,7 @@ const Profile = ({ navigate }) => {
 
   useEffect(() => {
     if (token) {
-      fetch('/users/user', {
+      fetch('/users/display-name', {
         headers: { 
           'Authorization': `Bearer ${token}` 
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "eslint": "^8.53.0"
+        "eslint": "^8.53.0",
+        "multer": "^1.4.5-lts.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -191,6 +192,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -208,6 +214,22 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/callsites": {
@@ -253,6 +275,25 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -645,6 +686,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -715,6 +761,33 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -726,15 +799,59 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -831,6 +948,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -857,6 +979,20 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -911,6 +1047,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -928,6 +1069,22 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -990,6 +1147,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -997,6 +1171,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1016,6 +1195,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "eslint": "^8.53.0"
+    "eslint": "^8.53.0",
+    "multer": "^1.4.5-lts.1"
   }
 }


### PR DESCRIPTION
Four major renamings:

`userId` in each post has been renamed to `author`.
`userId` in each comment has been renamed to `commenter`.
The method to return the display name in UsersController has been renamed from `FindSingleUserById` to `FindSingleDisplayNameById`.
The `/users/user` GET route has been renamed to `/users/display-name`.